### PR TITLE
Adjust unsafe blocks for the ByteBuffer impl

### DIFF
--- a/src/byte_buffer.rs
+++ b/src/byte_buffer.rs
@@ -53,8 +53,8 @@ impl ByteBuffer {
         self.head -= length;
         if self.head > 0 {
             // some data remaining, move them to the front of the buffer
+            let buf_ptr = self.buf.as_mut_ptr();
             unsafe {
-                let buf_ptr = self.buf.as_mut_ptr();
 
                 // Before:
                 //


### PR DESCRIPTION
In this function you use the unsafe keyword for one safe statement. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 